### PR TITLE
Add requirement for Soap PHP extension

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -91,6 +91,13 @@ function plugin_version_mantis() {
             'min' => PLUGIN_MANTIS_MIN_GLPI,
             'max' => PLUGIN_MANTIS_MAX_GLPI,
             'dev' => true
+         ],
+         'php' => [
+            'exts' => [
+               'soap'     => [
+                  'required' => true,
+               ]
+            ]
          ]
       ]
    ];


### PR DESCRIPTION
Soap PHP extension is mandatory to use this plugin. Adding it as requirement will prevent someone to install this plugin without having this extension installed and loaded.