### PR TITLE
Add GLPI 9.5 compatibility

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -28,7 +28,7 @@ define("PLUGIN_MANTIS_VERSION", "4.3.2");
 // Minimal GLPI version, inclusive
 define("PLUGIN_MANTIS_MIN_GLPI", "9.4");
 // Maximum GLPI version, exclusive
-define("PLUGIN_MANTIS_MAX_GLPI", "9.5");
+define("PLUGIN_MANTIS_MAX_GLPI", "9.6");
 
 /**
  * function to initialize the plugin


### PR DESCRIPTION
I did not find any usage of deprecated or removed GLPI core methods. Unless I miss something, no change is required (except this one) to be able to use plugin on GLPI 9.5.